### PR TITLE
Add support for building with MSVC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,10 @@
 *.log
 *.so
 *.dll
+*.exp
+*.lib
 *.o
+*.obj
 *.swp
 *.symbols
 core.*

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 MoonSDL2 is a Lua binding library for the [Simple DirectMedia Layer (SDL2)](https://www.libsdl.org).
 
-It runs on GNU/Linux and on Windows (MSYS2/MinGW) and requires 
+It runs on GNU/Linux and on Windows (MSYS2/MinGW or MSVC) and requires
 [Lua](http://www.lua.org/) (>=5.3),
 [SDL2](https://github.com/libsdl-org/SDL/releases/) (>= 2.26.0),
 [SDL_image](https://github.com/libsdl-org/SDL_image/releases/) (>= 2.6.3),
@@ -32,6 +32,27 @@ moonsdl2$ make
 moonsdl2$ sudo make install
 ```
 
+**On Windows Using Visual Studio**
+
+```
+> git clone https://github.com/stetre/moonsdl2/
+> cd moonsdl2\src
+> mingw32-make -f Makefile.msvc ^
+    LUAVER=<lua version> ^
+    LUA_INCDIR=<path to directory containing lua.h> ^
+    LUA_LIBDIR=<path to directory containing lua5X.dll> ^
+    SDL_INCDIR=<path to directory containing SDL2.h, SDL2_image.h, etc.> ^
+    SDL_LIBDIR=<path to directory containing SDL2.lib, SDL2_image.lib, etc.>
+```
+
+`<lua version>` is in dotted notation, like "5.1" (no quotes).
+
+Ensure all the other directories don't have spaces in their paths.
+
+If you don't have access to `mingw32-make`, you can edit `src\rebuild.bat` to
+suit your Lua version and paths, and then run it (from the `src` directory) to
+perform a full rebuild.
+
 #### Example
 
 The example below creates a window and draws a triangle using SDL2's 2D renderer.
@@ -48,8 +69,8 @@ local window = sdl.create_window("Hello, triangle!", nil, nil, 800, 600, sdl.WIN
 
 local renderer = sdl.create_renderer(window, nil, sdl.RENDERER_ACCELERATED|sdl.RENDERER_PRESENTVSYNC)
 
-local vertices = 
-    { --   position           color         
+local vertices =
+    { --   position           color
         { { 400, 150 }, { 255, 0, 0, 255 } },
         { { 200, 450 }, { 0, 0, 255, 255 } },
         { { 600, 450 }, { 0, 255, 0, 255 } },

--- a/src/Makefile.msvc
+++ b/src/Makefile.msvc
@@ -1,0 +1,62 @@
+# This requires GNU Make, as, for instance, mingw32-make.exe from MSYS2
+#
+# If you don't have GNU Make, you can use rebuild.bat to build the DLL
+# from scratch with no dependency checking. See that file for info.
+
+# Change these variables (or give them on the make command line) to suit
+# your Lua version and various local paths.
+LUAVER := 5.1
+LUA_LIBDIR := C:\Code\Tools\Lua\LuaJIT\lib
+LUA_INCDIR := C:\Code\Tools\Lua\LuaJIT\include
+SDL_LIBDIR := C:\Code\Tools\SDL2\lib
+SDL_INCDIR := C:\Code\Tools\SDL2\include\SDL2
+
+# This is the DLL that you'll need to load into Lua
+DLLNAME := moonsdl2.dll
+
+# We build a Release DLL dynamically linked to the MSVCR<version>.DLL runtime
+# library. If you would prefer the runtime library statically linked, set
+# DYNAMIC_RTL=0
+DYNAMIC_RTL := 1
+
+SHELL := cmd.exe
+MAKEFLAGS += --no-builtin-rules --no-builtin-variables
+.DEFAULT_GOAL := moonsdl2.dll
+.PHONY := clean rebuild
+
+CC := cl.exe
+LD := link.exe
+
+LIBDIRS := /LIBPATH:$(LUA_LIBDIR) /LIBPATH:$(SDL_LIBDIR)
+LIBS = lua$(subst .,,$(LUAVER)).lib \
+       SDL2.lib SDL2_image.lib SDL2_ttf.lib SDL2_mixer.lib
+
+INCDIRS := /I. /I$(LUA_INCDIR) /I$(SDL_INCDIR)
+
+ifeq ($(DYNAMIC_RTL),1)
+	RTLOPT := /MD
+else
+	RTLOPT := /MT
+endif
+
+CCFLAGS := /c /O2 /std:c11 $(RTLOPT) /LD /nologo /Zc:preprocessor /DMSVC_BUILDDLL \
+           /DLUAVER=$(LUAVER) $(INCDIRS)
+LDFLAGS := /DLL /MACHINE:X64 /NOLOGO /OPT:NOREF $(LIBDIRS)
+
+SRC := $(wildcard *.c)
+HEADERS := $(wildcard *.h)
+OBJS := $(SRC:%.c=%.obj)
+
+%.obj: %.c $(HEADERS)
+	$(CC) $(CCFLAGS) $<
+
+$(DLLNAME): $(OBJS)
+	$(LD) $(LDFLAGS) /OUT:$@ $^ $(LIBS)
+
+clean: FILES_TO_DEL := $(wildcard *.obj $(DLLNAME) $(DLLNAME:%.dll=%.exp) $(DLLNAME:%.dll=%.lib))
+clean:
+	$(if $(FILES_TO_DEL),del /Q $(FILES_TO_DEL),@echo Already clean)
+
+rebuild: clean
+	$(CC) $(CCFLAGS) $(SRC)
+	$(LD) $(LDFLAGS) /OUT:$(DLLNAME) *.obj $(LIBS)

--- a/src/Makefile.msvc
+++ b/src/Makefile.msvc
@@ -25,7 +25,6 @@ MAKEFLAGS += --no-builtin-rules --no-builtin-variables
 .PHONY := clean rebuild
 
 CC := cl.exe
-LD := link.exe
 
 LIBDIRS := /LIBPATH:$(LUA_LIBDIR) /LIBPATH:$(SDL_LIBDIR)
 LIBS = lua$(subst .,,$(LUAVER)).lib \
@@ -39,9 +38,10 @@ else
 	RTLOPT := /MT
 endif
 
-CCFLAGS := /c /O2 /std:c11 $(RTLOPT) /LD /nologo /Zc:preprocessor /DMSVC_BUILDDLL \
+CCFLAGS := /nologo /c /O2 /std:c11 /LD $(RTLOPT) /Zc:preprocessor /DMSVC_BUILDDLL \
            /DLUAVER=$(LUAVER) $(INCDIRS)
-LDFLAGS := /DLL /MACHINE:X64 /NOLOGO /OPT:NOREF $(LIBDIRS)
+LINKFLAGS := /nologo $(RTLOPT) /LD /Fe:$(DLLNAME:%.dll=%) /link /MACHINE:X64 /OPT:NOREF \
+             $(LIBDIRS)
 
 SRC := $(wildcard *.c)
 HEADERS := $(wildcard *.h)
@@ -51,7 +51,7 @@ OBJS := $(SRC:%.c=%.obj)
 	$(CC) $(CCFLAGS) $<
 
 $(DLLNAME): $(OBJS)
-	$(LD) $(LDFLAGS) /OUT:$@ $^ $(LIBS)
+	$(CC) $^ $(LIBS) $(LINKFLAGS)
 
 clean: FILES_TO_DEL := $(wildcard *.obj $(DLLNAME) $(DLLNAME:%.dll=%.exp) $(DLLNAME:%.dll=%.lib))
 clean:
@@ -59,4 +59,4 @@ clean:
 
 rebuild: clean
 	$(CC) $(CCFLAGS) $(SRC)
-	$(LD) $(LDFLAGS) /OUT:$(DLLNAME) *.obj $(LIBS)
+	$(CC) *.obj $(LIBS) $(LINKFLAGS)

--- a/src/internal.h
+++ b/src/internal.h
@@ -29,6 +29,13 @@
 #ifdef LINUX
 #define _ISOC11_SOURCE /* see man aligned_alloc(3) */
 #endif
+
+#ifdef MSVC_BUILDDLL
+  #define EXPORT __declspec(dllexport)
+#else
+  #define EXPORT
+#endif
+
 #include <string.h>
 #include <stdlib.h>
 #include <time.h>
@@ -62,7 +69,7 @@ void moonsdl2_utils_init(lua_State *L);
 #define copytable moonsdl2_copytable
 int copytable(lua_State *L);
 #define noprintf moonsdl2_noprintf
-int noprintf(const char *fmt, ...); 
+int noprintf(const char *fmt, ...);
 #define now moonsdl2_now
 double now(void);
 #define sleeep moonsdl2_sleeep
@@ -260,7 +267,7 @@ void pushsensortypeorint(lua_State *L, SDL_SensorType type);
 /* main.c */
 extern lua_State *moonsdl2_L;
 extern int moonsdl2_audio_is_open;
-int luaopen_moonsdl2(lua_State *L);
+EXPORT int luaopen_moonsdl2(lua_State *L);
 void moonsdl2_open_tracing(lua_State *L);
 void moonsdl2_open_flags(lua_State *L);
 void moonsdl2_open_enums(lua_State *L);
@@ -340,13 +347,13 @@ void moonsdl2_open_messagebox(lua_State *L);
     ts = now();                                             \
 } while(0);
 
-#else 
+#else
 
 #define DBG noprintf
 #define TR()
 #define BK()
-#define TSTART do {} while(0) 
-#define TSTOP do {} while(0)    
+#define TSTART do {} while(0)
+#define TSTOP do {} while(0)
 
 #endif /* DEBUG ------------------------------------------------- */
 

--- a/src/main.c
+++ b/src/main.c
@@ -136,7 +136,7 @@ static const struct luaL_Reg Functions[] =
         { NULL, NULL } /* sentinel */
     };
 
-int luaopen_moonsdl2(lua_State *L)
+EXPORT int luaopen_moonsdl2(lua_State *L)
 /* Lua calls this function to load the module */
     {
     moonsdl2_L = L;

--- a/src/rebuild.bat
+++ b/src/rebuild.bat
@@ -6,11 +6,10 @@ set LUA_LIBDIR=C:\Code\Tools\Lua\LuaJIT\lib
 set LUA_INCDIR=C:\Code\Tools\Lua\LuaJIT\include
 set SDL_LIBDIR=C:\Code\Tools\SDL2\lib
 set SDL_INCDIR=C:\Code\Tools\SDL2\include\SDL2
-set DLLNAME=moonsdl2.dll
 
 :: Clean up
 del /Q *.obj *.dll *.exp *.lib
 
 :: Build
-cl.exe /c /O2 /std:c11 /MD /LD /nologo /Zc:preprocessor /DMSVC_BUILDDLL /DLUAVER=%LUAVER% /I. /I%LUA_INCDIR% /I%SDL_INCDIR% *.c
-link.exe /DLL /MACHINE:X64 /NOLOGO /OPT:NOREF /LIBPATH:%LUA_LIBDIR% /LIBPATH:%SDL_LIBDIR% /OUT:%DLLNAME% *.obj lua51.lib SDL2.lib SDL2_image.lib SDL2_ttf.lib SDL2_mixer.lib
+cl.exe /c /O2 /std:c11 /MD /nologo /Zc:preprocessor /DMSVC_BUILDDLL /DLUAVER=%LUAVER% /I. /I%LUA_INCDIR% /I%SDL_INCDIR% *.c
+cl.exe *.obj SDL2.lib SDL2_image.lib SDL2_ttf.lib SDL2_mixer.lib lua51.lib /Fe:moonsdl2 /nologo /MD /LD /link /MACHINE:X64 /OPT:NOREF /LIBPATH:%LUA_LIBDIR% /LIBPATH:%SDL_LIBDIR%

--- a/src/rebuild.bat
+++ b/src/rebuild.bat
@@ -1,0 +1,16 @@
+@echo off
+
+:: Change these to suit your installation
+set LUAVER=5.1
+set LUA_LIBDIR=C:\Code\Tools\Lua\LuaJIT\lib
+set LUA_INCDIR=C:\Code\Tools\Lua\LuaJIT\include
+set SDL_LIBDIR=C:\Code\Tools\SDL2\lib
+set SDL_INCDIR=C:\Code\Tools\SDL2\include\SDL2
+set DLLNAME=moonsdl2.dll
+
+:: Clean up
+del /Q *.obj *.dll *.exp *.lib
+
+:: Build
+cl.exe /c /O2 /std:c11 /MD /LD /nologo /Zc:preprocessor /DMSVC_BUILDDLL /DLUAVER=%LUAVER% /I. /I%LUA_INCDIR% /I%SDL_INCDIR% *.c
+link.exe /DLL /MACHINE:X64 /NOLOGO /OPT:NOREF /LIBPATH:%LUA_LIBDIR% /LIBPATH:%SDL_LIBDIR% /OUT:%DLLNAME% *.obj lua51.lib SDL2.lib SDL2_image.lib SDL2_ttf.lib SDL2_mixer.lib

--- a/src/tree.h
+++ b/src/tree.h
@@ -27,6 +27,12 @@
 #ifndef _SYS_TREE_H_
 #define _SYS_TREE_H_
 
+#ifdef MSVC_BUILDDLL
+  #define ATTRIBUTE_UNUSED
+#else
+  #define ATTRIBUTE_UNUSED __attribute__((__unused__))
+#endif
+
 /*
  * This file defines data structures for different types of trees:
  * splay trees and red-black trees.
@@ -376,7 +382,7 @@ struct {                                \
 #define RB_PROTOTYPE(name, type, field, cmp)                \
     RB_PROTOTYPE_INTERNAL(name, type, field, cmp,)
 #define RB_PROTOTYPE_STATIC(name, type, field, cmp)         \
-    RB_PROTOTYPE_INTERNAL(name, type, field, cmp, __attribute__((__unused__)) static)
+    RB_PROTOTYPE_INTERNAL(name, type, field, cmp, ATTRIBUTE_UNUSED static)
 #define RB_PROTOTYPE_INTERNAL(name, type, field, cmp, attr)     \
 attr void name##_RB_INSERT_COLOR(struct name *, struct type *);     \
 attr void name##_RB_REMOVE_COLOR(struct name *, struct type *, struct type *);\
@@ -395,7 +401,7 @@ attr struct type *name##_RB_MINMAX(struct name *, int);         \
 #define RB_GENERATE(name, type, field, cmp)             \
     RB_GENERATE_INTERNAL(name, type, field, cmp,)
 #define RB_GENERATE_STATIC(name, type, field, cmp)          \
-    RB_GENERATE_INTERNAL(name, type, field, cmp, __attribute__((__unused__)) static)
+    RB_GENERATE_INTERNAL(name, type, field, cmp, ATTRIBUTE_UNUSED static)
 #define RB_GENERATE_INTERNAL(name, type, field, cmp, attr)      \
 attr void                               \
 name##_RB_INSERT_COLOR(struct name *head, struct type *elm)     \

--- a/src/utils.c
+++ b/src/utils.c
@@ -172,7 +172,7 @@ void sleeep(double seconds)
 
 #define time_init(L) do { (void)L; /* do nothing */ } while(0)
 
-#elif defined(MINGW)
+#elif defined(MINGW) || defined(MSVC_BUILDDLL)
 
 #include <windows.h>
 


### PR DESCRIPTION
Supplied a GNU Makefile (used with `mingw32-make`), a simple `.bat` file, and instructions in the `README`.